### PR TITLE
Remove incorrect LICENSE header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 Rhett Creighton
+
 # Out-of-source build directories
 /build/
 /build-clang/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2025 Rhett Creighton */
+
 cmake_minimum_required(VERSION 3.12)
 project(sha3 VERSION 1.0.0 LANGUAGES C)
 find_package(Threads REQUIRED)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2025 Rhett Creighton */
+
 # SHA3 Library – High-Performance Parallel SHA3-256
 
 This library provides a parallel, SIMD-accelerated implementation of SHA3-256 optimized for fixed-size messages.

--- a/bench.sh
+++ b/bench.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2025 Rhett Creighton */
 set -euo pipefail
 
 #---------------------------------------------------------------------

--- a/cmake/sha3Config.cmake.in
+++ b/cmake/sha3Config.cmake.in
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2025 Rhett Creighton */
+
 @PACKAGE_INIT@
 
 include("${CMAKE_CURRENT_LIST_DIR}/sha3Targets.cmake")

--- a/codex.md
+++ b/codex.md
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2025 Rhett Creighton */
+
 # SHA3 Library – High-Performance Usage Guide
 
 The SHA3 library provides:

--- a/examples/sha3_merkle_benchmark.c
+++ b/examples/sha3_merkle_benchmark.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2025 Rhett Creighton */
 /*
  * sha3_merkle_benchmark.c
  *


### PR DESCRIPTION
## Summary
- keep license headers across project files
- drop SPDX header from the LICENSE file

## Testing
- `git ls-files | grep -v '^vendor/' | grep -v '^LICENSE$' | while read f; do grep -q "SPDX-License-Identifier" "$f" || echo "$f"; done`
- `git ls-files | grep -v '^vendor/' | while read f; do grep -q "SPDX-License-Identifier" "$f" || echo "$f"; done` *(expected output: LICENSE)*